### PR TITLE
Closes #12: Move TaskCreate to homepage

### DIFF
--- a/app/Livewire/TaskCreate.php
+++ b/app/Livewire/TaskCreate.php
@@ -54,6 +54,8 @@ class TaskCreate extends Component
         $this->clearInput();
 
         session()->flash('message', 'Task created successfully.');
+
+        $this->dispatch('task-created');
     }
     
     public function clearInput()

--- a/app/Livewire/TaskIndex.php
+++ b/app/Livewire/TaskIndex.php
@@ -4,11 +4,20 @@ namespace App\Livewire;
 
 use App\Models\Task;
 use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
 class TaskIndex extends Component
 {
     public $tasks = '';
+
+    protected $listeners = ['taskCreated' => 'refreshTaskList'];
+
+    public function refreshTaskList()
+    {
+        $this->tasks = Auth::user()->tasks;
+
+    }
 
     public function delete(Task $task)
     {
@@ -16,6 +25,7 @@ class TaskIndex extends Component
         $this->tasks = Auth::user()->tasks;
     }
 
+    #[On('task-created')]
     public function mount()
     {
         $this->tasks = Auth::user()->tasks;

--- a/resources/views/livewire/task-create.blade.php
+++ b/resources/views/livewire/task-create.blade.php
@@ -1,218 +1,218 @@
 <div 
     x-data="{ inputValue: '', xcategory: '', xdaysPerWeek: '', typing: false, timeout: null }" 
-    class="flex justify-center mt-24 bg-gray-100 dark:bg-gray-900"
+    class="mt-24"
 >
-    <form wire:submit.prevent="createTask" class="w-11/12 sm:w-2/3 md:w-3/5 lg:w-2/5 p-6 bg-white dark:bg-gray-800 shadow-md rounded-lg">
-        <h2 class="text-xl font-bold mb-4 text-gray-800 dark:text-gray-200">Create a Task</h2>
+    <form wire:submit.prevent="createTask" class="shadow-md rounded-lg">
+        <div>
+            {{-- Session Messages --}}
+            @if (session()->has('message'))
+                <div 
+                    x-data="{ show: true }" 
+                    x-show="show" 
+                    x-init="setTimeout(() => show = false, 6000)" 
+                    class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4"
+                    role="alert"
+                >
+                    <strong class="font-bold">Success!</strong>
+                    <span class="block sm:inline">{{ session('message') }}</span>
+                </div>
+            @endif
 
-        {{-- Session Messages --}}
-        @if (session()->has('message'))
-            <div 
-                x-data="{ show: true }" 
-                x-show="show" 
-                x-init="setTimeout(() => show = false, 6000)" 
-                class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4"
-                role="alert"
-            >
-                <strong class="font-bold">Success!</strong>
-                <span class="block sm:inline">{{ session('message') }}</span>
-            </div>
-        @endif
-
-        {{-- Task Input --}}
-        <div class="mb-4">
-            <label
-                for="input1" 
-                class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-                Describe your Task
-            </label>
-            <input 
-                wire:model='task' 
-                x-model="inputValue"
-                x-on:input="typing = true; clearTimeout(timeout); timeout = setTimeout(() => typing = false, 500)"
-                type="text" 
-                id="input1"
-                class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                placeholder="Enter your task description..." 
-                required 
-            />
-        </div>
-        
-        {{-- Task Input Error --}}
-        @error('task')
-        <span class="text-red-600">
-            {{$message}}
-        </span>
-        @enderror
-
-        <div x-show="!typing && inputValue.trim() !== ''">
-            {{-- Category Input --}}
+            {{-- Task Input --}}
             <div class="mb-4">
-                <label for="category" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Task Category</label>
-                <select
-                    x-model="xcategory"
-                    wire:model="category" 
-                    id="category"
-                    class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                <label
+                    for="input1" 
+                    class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
-                    <option value="" selected>Select a category</option>
-                    <option value="personal">Personal</option>
-                    <option value="health">Health</option>
-                    <option value="finance">Finance</option>
-                    <option value="career">Career</option>
-                    <option value="school">School</option>
-                    <option value="home">Home</option>
-                    <option value="custom">Custom</option>
-                </select>
-                    
+                    Describe your Task
+                </label>
+                <input 
+                    wire:model='task' 
+                    x-model="inputValue"
+                    x-on:input="typing = true; clearTimeout(timeout); timeout = setTimeout(() => typing = false, 500)"
+                    type="text" 
+                    id="input1"
+                    class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="Enter your task description..." 
+                    required 
+                />
             </div>
-
-            @error('category')
-            <span class="text-red-600">
-                {{$message}}
-            </span>
-            @enderror
             
-            {{-- CustomCategory Input --}}
-            <template x-if="xcategory === 'custom'">
+            {{-- Task Input Error --}}
+            @error('task')
+            <span class="text-red-600">
+                {{$message}}
+            </span>
+            @enderror
+
+            <div x-show="!typing && inputValue.trim() !== ''">
+                {{-- Category Input --}}
                 <div class="mb-4">
-                    <label for="customCategory" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Custom Category</label>
-                    <input wire:model="customCategory" type="text" id="customCategory"
+                    <label for="category" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Task Category</label>
+                    <select
+                        x-model="xcategory"
+                        wire:model="category" 
+                        id="category"
                         class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-                        placeholder="Enter your custom category" required />
+                    >
+                        <option value="" selected>Select a category</option>
+                        <option value="personal">Personal</option>
+                        <option value="health">Health</option>
+                        <option value="finance">Finance</option>
+                        <option value="career">Career</option>
+                        <option value="school">School</option>
+                        <option value="home">Home</option>
+                        <option value="custom">Custom</option>
+                    </select>
+                        
                 </div>
-            </template>
 
-            {{-- Days per week Input --}}
-            <div class="mb-4" x-show="xcategory !== ''">
-                <label for="daysPerWeek" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Days Per Week</label>
-                <select
-                    x-model="xdaysPerWeek"
-                    wire:model.lazy="daysPerWeek" 
-                    class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                @error('category')
+                <span class="text-red-600">
+                    {{$message}}
+                </span>
+                @enderror
+                
+                {{-- CustomCategory Input --}}
+                <template x-if="xcategory === 'custom'">
+                    <div class="mb-4">
+                        <label for="customCategory" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Custom Category</label>
+                        <input wire:model="customCategory" type="text" id="customCategory"
+                            class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                            placeholder="Enter your custom category" required />
+                    </div>
+                </template>
+
+                {{-- Days per week Input --}}
+                <div class="mb-4" x-show="xcategory !== ''">
+                    <label for="daysPerWeek" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Days Per Week</label>
+                    <select
+                        x-model="xdaysPerWeek"
+                        wire:model.lazy="daysPerWeek" 
+                        class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                    >
+                        <option value="" selected>How many days per week?</option>
+                        <option value="1">1</option>
+                        <option value="2">2</option>
+                        <option value="3">3</option>
+                        <option value="4">4</option>
+                        <option value="5">5</option>
+                        <option value="6">6</option>
+                        <option value="7">7</option>
+                    </select>
+                </div>
+                @error('daysPerWeek')
+                <span class="text-red-600">
+                    {{$message}}
+                </span>
+                @enderror
+            
+                {{-- Days of week Input --}}
+                <div class="mb-4" x-show="xdaysPerWeek !== ''">
+                    <div class="text-blue-400">
+                        (Optional)
+                        <br>
+                        {{ count($daysOfWeek) . ' out of ' . $daysPerWeek . ' days selected.' }}
+                    </div>
+                    <label for="daysOfWeek" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Days Of Week</label>
+                    <div class="mt-2 space-y-2">
+                        <div>
+                            <input 
+                                type="checkbox" 
+                                id="monday" 
+                                value="monday" 
+                                x-model="xdaysOfWeek" 
+                                wire:model.lazy="daysOfWeek" 
+                                class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
+                            >
+                            <label for="monday" class="ml-2 text-gray-900 dark:text-gray-200">Monday</label>
+                        </div>
+                        <div>
+                            <input 
+                                type="checkbox" 
+                                id="tuesday" 
+                                value="tuesday" 
+                                x-model="xdaysOfWeek" 
+                                wire:model.lazy="daysOfWeek" 
+                                class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
+                            >
+                            <label for="tuesday" class="ml-2 text-gray-900 dark:text-gray-200">Tuesday</label>
+                        </div>
+                        <div>
+                            <input 
+                                type="checkbox" 
+                                id="wednesday" 
+                                value="wednesday" 
+                                x-model="xdaysOfWeek" 
+                                wire:model.lazy="daysOfWeek" 
+                                class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
+                            >
+                            <label for="wednesday" class="ml-2 text-gray-900 dark:text-gray-200">Wednesday</label>
+                        </div>
+                        <div>
+                            <input 
+                                type="checkbox" 
+                                id="thursday" 
+                                value="thursday" 
+                                x-model="xdaysOfWeek" 
+                                wire:model.lazy="daysOfWeek" 
+                                class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
+                            >
+                            <label for="thursday" class="ml-2 text-gray-900 dark:text-gray-200">Thursday</label>
+                        </div>
+                        <div>
+                            <input 
+                                type="checkbox" 
+                                id="friday" 
+                                value="friday" 
+                                x-model="xdaysOfWeek" 
+                                wire:model.lazy="daysOfWeek" 
+                                class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
+                            >
+                            <label for="friday" class="ml-2 text-gray-900 dark:text-gray-200">Friday</label>
+                        </div>
+                        <div>
+                            <input 
+                                type="checkbox" 
+                                id="saturday" 
+                                value="saturday" 
+                                x-model="xdaysOfWeek" 
+                                wire:model.lazy="daysOfWeek" 
+                                class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
+                            >
+                            <label for="saturday" class="ml-2 text-gray-900 dark:text-gray-200">Saturday</label>
+                        </div>
+                        <div>
+                            <input 
+                                type="checkbox" 
+                                id="sunday" 
+                                value="sunday" 
+                                x-model="xdaysOfWeek" 
+                                wire:model.lazy="daysOfWeek" 
+                                class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
+                            >
+                            <label for="sunday" class="ml-2 text-gray-900 dark:text-gray-200">Sunday</label>
+                        </div>
+                    </div>
+                </div>
+
+                @error('daysOfWeek')
+                <span class="text-red-600">
+                    {{$message}}
+                </span>
+                @enderror
+            </div>
+
+            <!-- Submit Button -->
+            <div class="text-right">
+                <button
+                    :disabled="inputValue.trim() === '' || xcategory === '' || xdaysPerWeek === ''"
+                    type="submit"
+                    class="disabled:bg-blue-200 disabled:hover:bg-blue-200 px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 dark:hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
                 >
-                    <option value="" selected>How many days per week?</option>
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                    <option value="3">3</option>
-                    <option value="4">4</option>
-                    <option value="5">5</option>
-                    <option value="6">6</option>
-                    <option value="7">7</option>
-                </select>
+                    Submit
+                </button>
             </div>
-            @error('daysPerWeek')
-            <span class="text-red-600">
-                {{$message}}
-            </span>
-            @enderror
-           
-            {{-- Days of week Input --}}
-            <div class="mb-4" x-show="xdaysPerWeek !== ''">
-                <div class="text-blue-400">
-                    (Optional)
-                    <br>
-                    {{ count($daysOfWeek) . ' out of ' . $daysPerWeek . ' days selected.' }}
-                </div>
-                <label for="daysOfWeek" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Days Of Week</label>
-                <div class="mt-2 space-y-2">
-                    <div>
-                        <input 
-                            type="checkbox" 
-                            id="monday" 
-                            value="monday" 
-                            x-model="xdaysOfWeek" 
-                            wire:model.lazy="daysOfWeek" 
-                            class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
-                        >
-                        <label for="monday" class="ml-2 text-gray-900 dark:text-gray-200">Monday</label>
-                    </div>
-                    <div>
-                        <input 
-                            type="checkbox" 
-                            id="tuesday" 
-                            value="tuesday" 
-                            x-model="xdaysOfWeek" 
-                            wire:model.lazy="daysOfWeek" 
-                            class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
-                        >
-                        <label for="tuesday" class="ml-2 text-gray-900 dark:text-gray-200">Tuesday</label>
-                    </div>
-                    <div>
-                        <input 
-                            type="checkbox" 
-                            id="wednesday" 
-                            value="wednesday" 
-                            x-model="xdaysOfWeek" 
-                            wire:model.lazy="daysOfWeek" 
-                            class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
-                        >
-                        <label for="wednesday" class="ml-2 text-gray-900 dark:text-gray-200">Wednesday</label>
-                    </div>
-                    <div>
-                        <input 
-                            type="checkbox" 
-                            id="thursday" 
-                            value="thursday" 
-                            x-model="xdaysOfWeek" 
-                            wire:model.lazy="daysOfWeek" 
-                            class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
-                        >
-                        <label for="thursday" class="ml-2 text-gray-900 dark:text-gray-200">Thursday</label>
-                    </div>
-                    <div>
-                        <input 
-                            type="checkbox" 
-                            id="friday" 
-                            value="friday" 
-                            x-model="xdaysOfWeek" 
-                            wire:model.lazy="daysOfWeek" 
-                            class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
-                        >
-                        <label for="friday" class="ml-2 text-gray-900 dark:text-gray-200">Friday</label>
-                    </div>
-                    <div>
-                        <input 
-                            type="checkbox" 
-                            id="saturday" 
-                            value="saturday" 
-                            x-model="xdaysOfWeek" 
-                            wire:model.lazy="daysOfWeek" 
-                            class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
-                        >
-                        <label for="saturday" class="ml-2 text-gray-900 dark:text-gray-200">Saturday</label>
-                    </div>
-                    <div>
-                        <input 
-                            type="checkbox" 
-                            id="sunday" 
-                            value="sunday" 
-                            x-model="xdaysOfWeek" 
-                            wire:model.lazy="daysOfWeek" 
-                            class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
-                        >
-                        <label for="sunday" class="ml-2 text-gray-900 dark:text-gray-200">Sunday</label>
-                    </div>
-                </div>
-            </div>
-
-            @error('daysOfWeek')
-            <span class="text-red-600">
-                {{$message}}
-            </span>
-            @enderror
-        </div>
-
-        <!-- Submit Button -->
-        <div class="text-right">
-            <button
-                :disabled="inputValue.trim() === '' || xcategory === '' || xdaysPerWeek === ''"
-                type="submit"
-                class="disabled:bg-blue-200 disabled:hover:bg-blue-200 px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 dark:hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
-                Submit
-            </button>
         </div>
     </form>
 </div>

--- a/resources/views/livewire/task-index.blade.php
+++ b/resources/views/livewire/task-index.blade.php
@@ -1,13 +1,26 @@
 <div class="w-11/12 sm:w-2/3 md:w-3/5 lg:w-2/5 mx-auto my-16">
-
-    <div class="my-8">
-        <h1 class="text-3xl text-gray-800 dark:text-white">
-            Non-negotiables.
+    <x-slot name="header">
+        <h1 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Non-Negotiables') }}
         </h1>
+    </x-slot>
+
+    <livewire:task-create></livewire:task-create>
+
+    @if ($tasks->isEmpty())
+    <div class="my-8">
         <h3 class="text-lg text-gray-700 dark:text-gray-200">
-            Get them done!
+            You have no tasks yet. Add one above!
         </h3>
     </div>
+    @else
+    <div class="my-8">
+        <h3 class="text-lg text-gray-700 dark:text-gray-200">
+            Get them done! You've got this!
+        </h3>
+    </div>
+    @endif
+
 
     @foreach ($tasks as $task)
         <div class="space-y-2">


### PR DESCRIPTION
Moved the task-create form to exist inside the task index.
This allows the user to instantly see the tasks they create.
Achieved this by using the dispatch('task-create) method inside my TaskCreate class, and listening for it with the #[On('task-create'] attribute above my mount() method inside the TaskIndex class. 
Next is to dry the code for both, and edit formatting and styling so it all looks aesthetically pleasing.
