### PR TITLE
Closes #23: change to use livewire form component

### DIFF
--- a/app/Livewire/Forms/TaskForm.php
+++ b/app/Livewire/Forms/TaskForm.php
@@ -60,6 +60,7 @@ class TaskForm extends Form
 
     public function setTask(Task $task)
     {
+        $this->showFields = true;
         $this->taskModel = $task;
         $this->task = $task->task;
         $this->category = $task->category;
@@ -100,6 +101,7 @@ class TaskForm extends Form
             'daysPerWeek' => $this->daysPerWeek,
         ]);
         
+        $this->showFields = false;
         session()->flash('message', 'Task updated successfully!');
     }
 }

--- a/app/Livewire/Forms/TaskForm.php
+++ b/app/Livewire/Forms/TaskForm.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Livewire\Forms;
+
+use App\Models\Task;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Validate;
+use Livewire\Form;
+
+class TaskForm extends Form
+{
+    #[Validate('required|string|min:3|max:255')]
+    public $task = '';
+
+    #[Validate('nullable|string|min:1|max:255')]
+    public $category = '';
+
+    #[Validate('nullable|integer|min:0|max:7')]
+    public $daysPerWeek = 0;
+
+    #[Validate('nullable|array')]
+    public $daysOfWeek = [];
+    
+    public $showFields = false;
+    public $taskModel;
+    public $days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+
+    public function increment()
+    {
+        $this->daysPerWeek++;
+        $this->updatedDaysPerWeek($this->daysPerWeek); 
+    }
+ 
+    public function decrement()
+    {
+        $this->daysPerWeek--;
+        $this->updatedDaysPerWeek($this->daysPerWeek); 
+    }
+
+    public function updatedDaysPerWeek($value)
+    {
+        if ($value === 0) {
+            $this->daysOfWeek = [];
+        } elseif ($value < 0) {
+            $this->daysPerWeek = 0;
+        } elseif ($value > 7) {
+            $this->daysPerWeek = 7;
+        }
+    }
+
+    public function updatedDaysOfWeek()
+    {
+        // Dynamically limit daysOfWeek based on daysPerWeek
+        $maxDays = (int) $this->daysPerWeek;
+        if (count($this->daysOfWeek) > $maxDays) {
+            $this->daysOfWeek = array_slice($this->daysOfWeek, 0, $maxDays);
+            $this->addError('daysOfWeek', "You can only select up to {$maxDays} daasdasys.");
+        }
+    }
+
+    public function setTask(Task $task)
+    {
+        $this->taskModel = $task;
+        $this->task = $task->task;
+        $this->category = $task->category;
+        $this->daysOfWeek = $task->daysOfWeek;
+        $this->daysPerWeek = $task->daysPerWeek;
+    }
+
+    public function create()
+    {
+        $this->validate();
+
+        Task::create([
+            'user_id' => Auth::id(),
+            'task' => $this->task,
+            'category' => $this->category,
+            'daysPerWeek' => $this->daysPerWeek,
+            'daysOfWeek' => $this->daysOfWeek,
+        ]);
+
+        $this->showFields = false;
+
+        session()->flash('message', 'Task created successfully.');
+    }
+
+    public function update()
+    {
+        $this->validate();
+
+        if (count($this->daysOfWeek) !== $this->daysPerWeek) {
+            $this->addError('daysOfWeek', "You must select exactly {$this->daysPerWeek} days.");
+            return;
+        }
+
+        $this->taskModel->update([
+            'task' => $this->task,
+            'category' => $this->category,
+            'daysOfWeek' => $this->daysOfWeek,
+            'daysPerWeek' => $this->daysPerWeek,
+        ]);
+        
+        session()->flash('message', 'Task updated successfully!');
+    }
+}

--- a/app/Livewire/TaskCreate.php
+++ b/app/Livewire/TaskCreate.php
@@ -2,57 +2,28 @@
 
 namespace App\Livewire;
 
+use App\Livewire\Forms\TaskForm;
 use App\Models\Task;
-use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\On;
-use Livewire\Attributes\Validate;
 use Livewire\Component;
-
-use function Laravel\Prompts\clear;
 
 class TaskCreate extends Component
 {   
-
-    #[Validate('required|string|min:3|max:255')]
-    public $task = '';
-
-    #[Validate('nullable|string|min:1|max:255')]
-    public $category = '';
-
-    #[Validate('nullable|string|min:1|max:255')]
-    public $customCategory = '';
-
-    #[Validate('nullable|integer|min:0|max:7')]
-    public $daysPerWeek = 0;
-
-    #[Validate('nullable|array')]
-    public $daysOfWeek = [];
-    
-    public $showFields = false;
-
-    public $days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+    public TaskForm $form;
 
     public function increment()
     {
-        $this->daysPerWeek++;
-        $this->updatedDaysPerWeek($this->daysPerWeek); 
+        $this->form->increment();
     }
  
     public function decrement()
     {
-        $this->daysPerWeek--;
-        $this->updatedDaysPerWeek($this->daysPerWeek); 
+        $this->form->decrement();
     }
 
     public function updatedDaysPerWeek($value)
     {
-        if ($value === 0) {
-            $this->daysOfWeek = [];
-        } elseif ($value < 0) {
-            $this->daysPerWeek = 0;
-        } elseif ($value > 7) {
-            $this->daysPerWeek = 7;
-        }
+        $this->form->updatedDaysPerWeek($value);
 
         $this->dispatch('updated-days');
     }
@@ -60,45 +31,21 @@ class TaskCreate extends Component
     #[On('updated-days')]
     public function updatedDaysOfWeek()
     {
-        // Dynamically limit daysOfWeek based on daysPerWeek
-        $maxDays = (int) $this->daysPerWeek;
-        if (count($this->daysOfWeek) > $maxDays) {
-            $this->daysOfWeek = array_slice($this->daysOfWeek, 0, $maxDays);
-            $this->addError('daysOfWeek', "You can only select up to {$maxDays} daasdasys.");
-        }
+        $this->form->updatedDaysOfWeek();
     }
 
     public function createTask()
     {
-        $this->validate();
-
-        $finalCategory = $this->category === 'custom' ? $this->customCategory : $this->category;
-
-        Task::create([
-            'user_id' => Auth::id(),
-            'task' => $this->task,
-            'category' => $finalCategory,
-            'daysPerWeek' => $this->daysPerWeek ?: 0,
-            'daysOfWeek' => $this->daysOfWeek,
+        $this->form->create();
+        $this->reset([
+            'form.task',
+            'form.category',
+            'form.daysOfWeek',
+            'form.daysPerWeek',
         ]);
-
-        $this->clearInput();
-
-        session()->flash('message', 'Task created successfully.');
-
         $this->dispatch('task-created');
     }
     
-    public function clearInput()
-    {
-        $this->showFields = false;
-        $this->task = '';
-        $this->category = '';
-        $this->customCategory = '';
-        $this->daysPerWeek = '';
-        $this->daysOfWeek = [];
-    }
-
     public function render()
     {
         return view('livewire.task-create');

--- a/app/Livewire/TaskEdit.php
+++ b/app/Livewire/TaskEdit.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use App\Livewire\Forms\TaskForm;
 use App\Models\Task;
 use Livewire\Attributes\Lazy;
 use Livewire\Attributes\On;
@@ -11,78 +12,33 @@ use Livewire\Component;
 #[Lazy]
 class TaskEdit extends Component
 {
-    #[Validate('required|string|min:3|max:255')]
-    public $task = '';
-
-    #[Validate('nullable|string|min:1|max:255')]
-    public $category = '';
-
-    #[Validate('nullable|string|min:1|max:255')]
-    public $customCategory = '';
-
-    #[Validate('nullable|integer|min:0|max:7')]
-    public $daysPerWeek = 0;
-
-    #[Validate('nullable|array')]
-    public $daysOfWeek = [];
-
-    public $taskModel;
-    public $days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
-
+    public TaskForm $form;
 
     public function mount(Task $task)
     {
-        $this->taskModel = $task;
-        $this->task = $task->task;
-        $this->category = $task->category;
-        $this->daysOfWeek = $task->daysOfWeek;
-        $this->daysPerWeek = $task->daysPerWeek;
+       $this->form->setTask($task);
     }
 
     public function save()
     {
-        $this->validate();
-
-        $finalCategory = $this->category === 'custom' ? $this->customCategory : $this->category;
-
-        if (count($this->daysOfWeek) !== $this->daysPerWeek) {
-            $this->addError('daysOfWeek', "You must select exactly {$this->daysPerWeek} days.");
-            return;
-        }
-
-        $this->taskModel->update([
-            'task' => $this->task,
-            'category' => $finalCategory,
-            'daysOfWeek' => $this->daysOfWeek,
-            'daysPerWeek' => $this->daysPerWeek,
-        ]);
-        
-        session()->flash('message', 'Task updated successfully!');
+        $this->form->update();
 
         $this->dispatch('task-updated');
     }
 
     public function increment()
     {
-        $this->daysPerWeek++;
-        $this->updatedDaysPerWeek($this->daysPerWeek); 
+        $this->form->increment();
     }
  
     public function decrement()
     {
-        $this->daysPerWeek--;
-        $this->updatedDaysPerWeek($this->daysPerWeek); 
+        $this->form->decrement();
     }
 
     public function updatedDaysPerWeek($value)
     {
-        if ($value === 0) {
-            $this->daysOfWeek = [];
-        } elseif ($value < 0) {
-            $this->daysPerWeek = 0;
-        } elseif ($value > 7) {
-            $this->daysPerWeek = 7;
-        }
+        $this->form->updatedDaysPerWeek($value);
 
         $this->dispatch('updated-days');
     }
@@ -90,12 +46,7 @@ class TaskEdit extends Component
     #[On('updated-days')]
     public function updatedDaysOfWeek()
     {
-        // Dynamically limit daysOfWeek based on daysPerWeek
-        $maxDays = (int) $this->daysPerWeek;
-        if (count($this->daysOfWeek) > $maxDays) {
-            $this->daysOfWeek = array_slice($this->daysOfWeek, 0, $maxDays);
-            $this->addError('daysOfWeek', "You can only select up to {$maxDays} daasdasys.");
-        }
+        $this->form->updatedDaysOfWeek();
     }
 
     public function render()

--- a/resources/views/components/task-create/category-input.blade.php
+++ b/resources/views/components/task-create/category-input.blade.php
@@ -1,12 +1,12 @@
 <div 
     class="mb-4"
-    :class="{ 'w-1/3': $wire.category === 'custom', 'w-full': $wire.category !== 'custom' }"
+    :class="{ 'w-1/3': $wire.form.category === 'custom', 'w-full': $wire.form.category !== 'custom' }"
 >
     <label for="category" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
         Task Category
     </label>
     <select
-        wire:model="category" 
+        wire:model="form.category" 
         id="category"
         class="mt-1 block w-full px-4 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
     >

--- a/resources/views/components/task-create/custom-category.blade.php
+++ b/resources/views/components/task-create/custom-category.blade.php
@@ -1,4 +1,4 @@
-<template x-if="$wire.category === 'custom'" class="w-full">
+<template x-if="$wire.form.category === 'custom'" class="w-full">
     <div class="mb-4">
         <label 
             for="customCategory" 
@@ -7,7 +7,7 @@
             Custom Category
         </label>
         <input 
-            wire:model="customCategory" 
+            wire:model="form.customCategory" 
             type="text" 
             id="customCategory"
             class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"

--- a/resources/views/components/task-create/days-checkbox.blade.php
+++ b/resources/views/components/task-create/days-checkbox.blade.php
@@ -3,7 +3,7 @@
         type="checkbox" 
         id="{{ $day }}" 
         value="{{ $day }}" 
-        wire:model.lazy="daysOfWeek" 
+        wire:model.lazy="form.daysOfWeek" 
         class="form-checkbox h-4 w-4 text-blue-600 transition duration-150 ease-in-out border-gray-300 dark:border-gray-600"
     >
     <label for="{{ $day }}" class="ml-1 text-gray-900 dark:text-gray-200">

--- a/resources/views/components/task-create/days-of-week.blade.php
+++ b/resources/views/components/task-create/days-of-week.blade.php
@@ -1,6 +1,6 @@
 <div
     class="mb-4" 
-    x-show="$wire.daysPerWeek > 0"
+    x-show="$wire.form.daysPerWeek > 0"
     x-transition:enter.duration.500ms
     x-transition:leave.duration.0ms
 >

--- a/resources/views/components/task-create/days-per-week.blade.php
+++ b/resources/views/components/task-create/days-per-week.blade.php
@@ -10,15 +10,15 @@
             wire:click="decrement"
             type="button"
             class="rounded-l-lg size-10 leading-10 text-gray-600 bg-gray-600 transition hover:opacity-75 dark:text-gray-300"
-            :disabled="$wire.daysPerWeek <= 0"
+            :disabled="$wire.form.daysPerWeek <= 0"
         >
             &minus;
         </button>
     
         <input
-            wire:model.lazy="daysPerWeek" 
+            wire:model.lazy="form.daysPerWeek" 
             type="number"
-            id="Quantity"
+            id="quantity"
             class="h-10  w-16 border-transparent text-center [-moz-appearance:_textfield] sm:text-sm dark:bg-gray-700 dark:text-white [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none"
         />
     
@@ -26,7 +26,7 @@
             wire:click="increment"
             type="button"
             class="rounded-r-lg size-10 leading-10 text-gray-600 bg-gray-600 transition hover:opacity-75 dark:text-gray-300"
-            :disabled="$wire.daysPerWeek >= 7"
+            :disabled="$wire.form.daysPerWeek >= 7"
         >
             &plus;
         </button>

--- a/resources/views/components/task-create/submit-button.blade.php
+++ b/resources/views/components/task-create/submit-button.blade.php
@@ -1,9 +1,8 @@
 <div class="text-right">
     <button
         x-show="showFields"
-        x-on:click="{showFields = false}"
         wire:click.prevent="createTask"
-        :disabled="$wire.task.trim() === ''"
+        :disabled="$wire.form.task.trim() === ''"
         type="submit"
         class="disabled:bg-blue-200 disabled:hover:bg-blue-200 px-4 py-2 my-4 bg-blue-600 dark:bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 dark:hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
     >

--- a/resources/views/components/task-create/task-input.blade.php
+++ b/resources/views/components/task-create/task-input.blade.php
@@ -12,7 +12,7 @@
         </span>
     </label>
     <input 
-        wire:model.blur='task' 
+        wire:model.blur='form.task' 
         x-on:input="
             typing = true; 
             showFields = true;
@@ -22,7 +22,7 @@
         autocomplete="off"
         type="text" 
         id="task"
-        class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 placeholder-gray-100"
+        class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 placeholder-gray-100 @error('form.task') required:border-red-500 @enderror"
         placeholder="Add a non-negotiable..." 
         required 
     />

--- a/resources/views/livewire/task-create.blade.php
+++ b/resources/views/livewire/task-create.blade.php
@@ -1,5 +1,5 @@
 <div 
-    x-data="{ inputValue: '', showFields: @entangle('showFields'), typing: false, timeout: null }" 
+    x-data="{ inputValue: '', showFields: @entangle('form.showFields'), typing: false, timeout: null }" 
 >
     <form wire:submit.prevent="createTask" class="shadow-md rounded-lg">
         <div>
@@ -10,7 +10,7 @@
             <x-task-create.task-input />
         
             {{-- Task Input Error --}}
-            <x-task-create.error-message type="task"/>
+            <x-task-create.error-message type="form.task"/>
             
             {{-- Optional Inputs --}}
             <x-task-create.optional-inputs>
@@ -21,7 +21,7 @@
                     <x-task-create.category-input />
                     
                     {{-- Category Input Error --}}  
-                    <x-task-create.error-message type="category"/>
+                    <x-task-create.error-message type="form.category"/>
                     
                     {{-- Custom Category --}}
                     <x-task-create.custom-category />
@@ -34,20 +34,19 @@
                     <x-task-create.days-per-week />
                     
                     {{-- Days Per Week Input Error --}}
-                    <x-task-create.error-message type="daysPerWeek"/>
+                    <x-task-create.error-message type="form.daysPerWeek"/>
 
                 </x-slot>
 
                 <x-slot:daysOfWeek>
-                
                     {{-- Days of week Input --}}
                     <x-task-create.days-of-week 
-                        :days="$days" 
-                        :daysOfWeek="$daysOfWeek" 
-                        :daysPerWeek="$daysPerWeek"
+                        :days="$form->days" 
+                        :daysOfWeek="$form->daysOfWeek" 
+                        :daysPerWeek="$form->daysPerWeek"
                     />
 
-                    <x-task-create.error-message type="daysOfWeek"/>
+                    <x-task-create.error-message type="form.daysOfWeek"/>
 
                 </x-slot>
 

--- a/resources/views/livewire/task-edit.blade.php
+++ b/resources/views/livewire/task-edit.blade.php
@@ -13,7 +13,7 @@
                     Non-Negotiable
                 </label>
                 <input 
-                    wire:model.blur='task' 
+                    wire:model.blur='form.task' 
                     autocomplete="off"
                     type="text" 
                     id="task"
@@ -28,13 +28,13 @@
             <div class="flex justify-between items-center gap-x-4">
                 <div 
                     class="mb-4"
-                    :class="{ 'w-1/3': $wire.category === 'custom', 'w-full': $wire.category !== 'custom' }"
+                    :class="{ 'w-1/3': $wire.form.category === 'custom', 'w-full': $wire.form.category !== 'custom' }"
                 >
                     <label for="category" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                         Task Category
                     </label>
                     <select
-                        wire:model="category" 
+                        wire:model="form.category" 
                         id="category"
                         class="mt-1 block w-full px-4 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                     >
@@ -54,18 +54,18 @@
                 <x-task-create.error-message type="category"/>
                 
                 {{-- Custom Category --}}
-                <template x-if="$wire.category === 'custom'" class="w-full">
+                <template x-if="$wire.form.category === 'custom'" class="w-full">
                     <div class="mb-4">
                         <label 
-                            for="customCategory" 
+                            for="category" 
                             class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >
                             Custom Category
                         </label>
                         <input 
-                            wire:model="customCategory" 
+                            wire:model="category" 
                             type="text" 
-                            id="customCategory"
+                            id="category"
                             class="mt-1 block w-full px-3 py-2 bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                             placeholder="Enter category..." 
                             required 
@@ -85,13 +85,13 @@
                             wire:click="decrement"
                             type="button"
                             class="rounded-l-lg size-10 leading-10 text-gray-600 bg-gray-600 transition hover:opacity-75 dark:text-gray-300"
-                            :disabled="$wire.daysPerWeek <= 0"
+                            :disabled="$wire.form.daysPerWeek <= 0"
                         >
                             &minus;
                         </button>
                     
                         <input
-                            wire:model.lazy="daysPerWeek" 
+                            wire:model.lazy="form.daysPerWeek" 
                             type="number"
                             id="Quantity"
                             class="h-10 w-16 border-transparent text-center [-moz-appearance:_textfield] sm:text-sm dark:bg-gray-700 dark:text-white [&::-webkit-inner-spin-button]:m-0 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-outer-spin-button]:appearance-none"
@@ -101,7 +101,7 @@
                             wire:click="increment"
                             type="button"
                             class="rounded-r-lg size-10 leading-10 text-gray-600 bg-gray-600 transition hover:opacity-75 dark:text-gray-300"
-                            :disabled="$wire.daysPerWeek >= 7"
+                            :disabled="$wire.form.daysPerWeek >= 7"
                         >
                             &plus;
                         </button>
@@ -113,7 +113,7 @@
 
             <div
                 class="mb-4" 
-                x-show="$wire.daysPerWeek > 0"
+                x-show="$wire.form.daysPerWeek > 0"
                 x-transition:enter.duration.500ms
                 x-transition:leave.duration.0ms
             >
@@ -122,12 +122,12 @@
                 </div>
                 <label for="daysOfWeek" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Days Of Week</label>
                 <div class="mt-2 flex items-center justify-between">
-                    @foreach ($days as $day)
-                        <x-task-create.days-checkbox :day="$day" :daysOfWeek="$daysOfWeek"/>
+                    @foreach ($form->days as $day)
+                        <x-task-create.days-checkbox :day="$day" :daysOfWeek="$form->daysOfWeek"/>
                     @endforeach
                 </div>
                 <div class="text-blue-400 my-4">
-                    {{ count($daysOfWeek) . ' out of ' . $daysPerWeek . ' days selected.' }}
+                    {{ count($form->daysOfWeek) . ' out of ' . $form->daysPerWeek . ' days selected.' }}
                 </div>
             </div>
 
@@ -135,7 +135,7 @@
 
             <div class="text-right">
                 <button
-                    :disabled="$wire.task.trim() === ''"
+                    :disabled="$wire.form.task.trim() === ''"
                     type="submit"
                     class="disabled:bg-blue-200 disabled:hover:bg-blue-200 px-4 py-2 my-4 bg-blue-600 dark:bg-blue-500 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 dark:hover:bg-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
                 >

--- a/resources/views/livewire/task-edit.blade.php
+++ b/resources/views/livewire/task-edit.blade.php
@@ -1,5 +1,7 @@
-<div>
-    <form wire:submit.prevent="save" class="shadow-md rounded-lg">
+<div 
+    x-data="{ showFields: @entangle('form.showFields') }" 
+>
+    <form wire:submit.prevent="save" class="shadow-md rounded-lg" x-show="showFields">
         <div>
             {{-- Session Messages --}}
             <x-task-create.session-message />


### PR DESCRIPTION
All form logic moved to a form component to reduce boilerplate and make it accessible across the form components.