### PR TITLE
Closes #30: fix update message from dissapearing

### DIFF
--- a/app/Livewire/TaskEdit.php
+++ b/app/Livewire/TaskEdit.php
@@ -14,6 +14,8 @@ class TaskEdit extends Component
 {
     public TaskForm $form;
     public $formContext = 'edit';
+    public $events = ['task-updated', 'update-message'];
+    
 
     public function updatedFormTaskDays($value)
     {
@@ -31,7 +33,9 @@ class TaskEdit extends Component
     public function editTask()
     {
         $this->form->save();
-        $this->dispatch('task-updated', $this->form->taskModel);
+        foreach ($this->events as $event) {
+            $this->dispatch($event, $this->form->taskModel->id);
+        }
     }
 
     public function render()

--- a/app/Livewire/TaskIndex.php
+++ b/app/Livewire/TaskIndex.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use App\Livewire\Forms\TaskForm;
 use App\Models\Task;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Computed;
@@ -12,6 +13,7 @@ class TaskIndex extends Component
 {
     public $tasks;
     public $editing = [];
+    public $updated = null;
 
     #[Computed]
     public function groupedTasks()
@@ -23,12 +25,12 @@ class TaskIndex extends Component
     }
 
     #[On('task-updated')]
-    public function toggleEdit(Task $task)
+    public function toggleEdit($task)
     {
-        if (isset($this->editing[$task->id])) {
-            unset($this->editing[$task->id]);
+        if (isset($this->editing[$task])) {
+            unset($this->editing[$task]);
         } else {
-            $this->editing[$task->id] = true;
+            $this->editing[$task] = true;
         }
     }
 
@@ -37,6 +39,13 @@ class TaskIndex extends Component
         $task->delete();
         $this->tasks = Auth::user()->tasks;
         $this->groupedTasks;
+    }
+
+    #[On('update-message')]
+    public function editMessage($task)
+    {
+        $this->updated = $task;
+        session()->flash("update-message", 'Task updated successfully!');
     }
 
     #[On('task-created', 'task-updated')]

--- a/resources/views/components/task/update-message.blade.php
+++ b/resources/views/components/task/update-message.blade.php
@@ -1,0 +1,12 @@
+@if (session()->has("update-message"))
+    <div 
+        x-data="{ show: true }" 
+        x-show="show" 
+        x-init="setTimeout(() => show = false, 6000)" 
+        class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4"
+        role="alert"
+    >
+        <strong class="font-bold">Success!</strong>
+        <span class="block sm:inline">{{ session('message') }}</span>
+    </div>
+@endif

--- a/resources/views/livewire/task-index.blade.php
+++ b/resources/views/livewire/task-index.blade.php
@@ -5,6 +5,8 @@
         </h1>
     </x-slot>
 
+    <x-task.session-message />
+
     <livewire:task-create></livewire:task-create>
 
     @if ($tasks->isEmpty())
@@ -94,6 +96,9 @@
             </label>
             @if (isset($editing[$task->id]))
             <livewire:task-edit :task="$task" :key="$task->id"></livewire:task-edit>
+            @endif
+            @if ($task->id === $updated)
+                <x-task.update-message :updated="$updated"/>
             @endif
         </div>
         @endforeach


### PR DESCRIPTION
Had to create a new event, method, and component to handle the success message for each individual task that was updated. Works great and now everything has a nice message when created or edited.